### PR TITLE
Update for Gitbook 3+

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,13 +10,9 @@ removeEntities = function(string) {
 module.exports = {
   hooks: {
     page: function(page) {
-      for (var i in page.sections) {
-        if(page.sections[i].type != "normal") {
-          continue;
-        }
-        page.sections[i].content = removeEntities(page.sections[i].content);
-        page.sections[i].content = typogr.typogrify(page.sections[i].content);
-      }
+      page.content = removeEntities(page.content);
+      page.content = typogr.typogrify(page.content);
+
       return page;
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "main": "index.js",
     "version": "0.0.5",
     "engines": {
-        "gitbook": "*"
+        "gitbook": ">3.x.x"
     },
     "homepage": "https://github.com/nathanwebb/gitbook-plugin-typogr",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "main": "index.js",
     "version": "0.0.5",
     "engines": {
-        "gitbook": ">3.x.x"
+        "gitbook": ">=3.2.0"
     },
     "homepage": "https://github.com/nathanwebb/gitbook-plugin-typogr",
     "repository": {


### PR DESCRIPTION
Looks like the API for plugins has changed a fair bit in Gitbook 3:

https://toolchain.gitbook.com/plugins/hooks.html

In particular, looks like `page.sections` has been ditched. This PR gets the plugin working with the latest version(s) of Gitbook :blush:.